### PR TITLE
reasonable default for httpoison_options

### DIFF
--- a/lib/readability.ex
+++ b/lib/readability.ex
@@ -72,7 +72,7 @@ defmodule Readability do
   @spec summarize(url, options) :: Summary.t
   def summarize(url, opts \\ []) do
     opts = Keyword.merge(opts, [page_url: url])
-    httpoison_options = Application.get_env :readability, :httpoison_options
+    httpoison_options = Application.get_env :readability, :httpoison_options, []
     %{status_code: _, body: raw_html} = HTTPoison.get!(url, [], httpoison_options)
     html_tree = Helper.normalize(raw_html)
     article_tree = html_tree


### PR DESCRIPTION
i got following error w/o httpoison_options setting in config.exs file
```
iex(1)> Readability.summarize("http://www.naver.com")
Readability.summarize("http://www.naver.com")
** (FunctionClauseError) no function clause matching in Keyword.has_key?/2
         (elixir) lib/keyword.ex:631: Keyword.has_key?(nil, :params)
      (httpoison) lib/httpoison.ex:66: HTTPoison.request/5
      (httpoison) lib/httpoison.ex:66: HTTPoison.request!/5
    (readability) lib/readability.ex:76: Readability.summarize/2
```
i think reasonable default value will help.
