### PR TITLE
Upgrade to floki 0.18.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: elixir
 
 elixir:
-  - 1.2.6
   - 1.3.4
   - 1.4.1
   - 1.5.0

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ def application do
 end
 ```
 
+Note: Readability requires Elixir 1.3 or higher.
+
 ## Usage
 
 ### Examples

--- a/lib/readability/helper.ex
+++ b/lib/readability/helper.ex
@@ -79,9 +79,9 @@ defmodule Readability.Helper do
   Check html_tree can be candidate or not.
   """
   @spec candidate_tag?(html_tree) :: boolean
-  def candidate_tag?(html_tree) do
-    Enum.any?(candidates_selector(), fn(selector) ->
-      Floki.Selector.match?(html_tree, selector)
+  def candidate_tag?({tag, _, _} = html_tree) do
+    Enum.any?(["p", "td"], fn(candidate_tag) ->
+      tag == candidate_tag
       && (text_length(html_tree)) >= Readability.default_options[:min_text_length]
     end)
   end
@@ -98,13 +98,5 @@ defmodule Readability.Helper do
     |> String.replace(Readability.regexes(:normalize), " ")
     |> Floki.parse
     |> Floki.filter_out(:comment)
-  end
-
-  defp candidates_selector do
-    ["p", "td"]
-    |> Enum.map(fn(s) ->
-         tokens = Floki.SelectorTokenizer.tokenize(s)
-         Floki.SelectorParser.parse(tokens)
-       end)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -40,7 +40,7 @@ defmodule Readability.Mixfile do
   #
   # Type "mix help deps" for more examples and options
   defp deps do
-    [{:floki, "~> 0.14.0"},
+    [{:floki, "~> 0.18.0"},
      {:httpoison, "~> 0.13.0"},
      {:ex_doc, "~> 0.14", only: :dev},
      {:credo, "~> 0.6.1", only: [:dev, :test]},

--- a/mix.exs
+++ b/mix.exs
@@ -12,7 +12,7 @@ defmodule Readability.Mixfile do
   def project do
     [app: :readability,
      version: @version,
-     elixir: "~> 1.2",
+     elixir: "~> 1.3",
      description: @description,
      package: package(),
      build_embedded: Mix.env == :prod,

--- a/mix.lock
+++ b/mix.lock
@@ -4,7 +4,7 @@
   "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], []},
   "earmark": {:hex, :earmark, "1.2.3", "206eb2e2ac1a794aa5256f3982de7a76bf4579ff91cb28d0e17ea2c9491e46a4", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.16.3", "cd2a4cfe5d26e37502d3ec776702c72efa1adfa24ed9ce723bb565f4c30bd31a", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, optional: false]}]},
-  "floki": {:hex, :floki, "0.14.0", "91a6be57349e10a63cf52d7890479a19012cef9185fa93c305d4fe42e6a50dee", [:mix], [{:mochiweb, "~> 2.15", [hex: :mochiweb, optional: false]}]},
+  "floki": {:hex, :floki, "0.18.1", "6f903e3074357fe9756079d0f607e430589912f698b5c5e5970af08daba1537c", [:mix], [{:mochiweb, "~> 2.15", [hex: :mochiweb, repo: "hexpm", optional: false]}], "hexpm"},
   "hackney": {:hex, :hackney, "1.9.0", "51c506afc0a365868469dcfc79a9d0b94d896ec741cfd5bd338f49a5ec515bfe", [:rebar3], [{:certifi, "2.0.0", [hex: :certifi, optional: false]}, {:idna, "5.1.0", [hex: :idna, optional: false]}, {:metrics, "1.0.1", [hex: :metrics, optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, optional: false]}, {:ssl_verify_fun, "1.1.1", [hex: :ssl_verify_fun, optional: false]}]},
   "httpoison": {:hex, :httpoison, "0.13.0", "bfaf44d9f133a6599886720f3937a7699466d23bb0cd7a88b6ba011f53c6f562", [:mix], [{:hackney, "~> 1.8", [hex: :hackney, optional: false]}]},
   "idna": {:hex, :idna, "5.1.0", "d72b4effeb324ad5da3cab1767cb16b17939004e789d8c0ad5b70f3cea20c89a", [:rebar3], [{:unicode_util_compat, "0.3.1", [hex: :unicode_util_compat, optional: false]}]},


### PR DESCRIPTION
I checked that the ```match?``` function is no longer public in Floki version 0.15.0.

I fixed the missing method by replicating what the method did and verified that all the tests still pass.
What do you think?

Issue: #31 