### PR TITLE
Do a case-insensitive content-type check

### DIFF
--- a/lib/readability.ex
+++ b/lib/readability.ex
@@ -113,7 +113,7 @@ defmodule Readability do
     headers
     |> Enum.find(
       {"Content-Type", "text/plain"},  # default
-      fn({key, _}) -> key == "Content-Type" end)
+      fn({key, _}) -> String.downcase(key) == "content-type" end)
     |> elem(1)
   end
 

--- a/test/readability_http_test.exs
+++ b/test/readability_http_test.exs
@@ -66,4 +66,20 @@ defmodule ReadabilityHttpTest do
       assert result_html =~ ~r/connected computing devices\".<\/p><\/div><\/div>$/
     end
   end
+
+  test "response with content-type in different case is parsed correctly" do
+    # HTTP header keys are case insensitive (RFC2616 - Section 4.2)
+    url = "https://news.bbc.co.uk/test.html"
+    content = TestHelper.read_fixture("bbc.html")
+    response = %HTTPoison.Response{
+      status_code: 200,
+      headers: [{"content-Type", "text/html; charset=UTF-8"}],
+      body: content}
+    
+    with_mock HTTPoison, [get!: fn(_url, _headers, _opts) -> response end] do
+      %Readability.Summary{article_html: result_html} = Readability.summarize(url)
+
+      assert result_html =~ ~r/connected computing devices\".<\/p><\/div><\/div>$/
+    end
+  end
 end


### PR DESCRIPTION
While doing some fix yesterday, I ran a local web server hosting some articles I want to test. However, I noticed that the library parse all the articles I host as plain-text instead of HTML.
I checked and found that the reason that happens is that the web server set the header content-type key in a different case thus failing the "Content-Type" check in the library. 

According to RFC 2616 (Section 4.2), the HTTP header field names are case-insensitive.