### PR TITLE
When we regex-check the MIME header we should also support zero space…

### DIFF
--- a/lib/readability.ex
+++ b/lib/readability.ex
@@ -61,7 +61,7 @@ defmodule Readability do
             protect_attrs: ~r/^(?!id|rel|for|summary|title|href|src|alt|srcdoc)/i
            ]
 
-  @markup_mimes ~r/^(application|text)\/[a-z\-_\.\+]+ml(;\s+charset=.*)?$/i
+  @markup_mimes ~r/^(application|text)\/[a-z\-_\.\+]+ml(;\s*charset=.*)?$/i
 
   @type html_tree :: tuple | list
   @type raw_html :: binary


### PR DESCRIPTION
Problem statement:

Some of the publication sites would return MIME headers as such `text/html;charset=utf-8` and it would fails the `Readability.summarize(url)` routine where internally we are comparing the MIME header against `~r/^(application|text)\/[a-z\-_\.\+]+ml(;\s+charset=.*)?$/i` where it requires a space between `text/html;` and `charset=foo-bar`.

My PR simply changed the regex to allow zero to multiple number of white spaces between them.