### PR TITLE
Add Elixir 1.6 formatter config file and formatted the codebase

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,4 @@
+# Used by "mix format"
+[
+  inputs: ["mix.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/lib/readability/article_builder.ex
+++ b/lib/readability/article_builder.ex
@@ -20,12 +20,18 @@ defmodule Readability.ArticleBuilder do
   @spec build(html_tree, options) :: html_tree
   def build(html_tree, opts) do
     origin_tree = html_tree
-    html_tree = html_tree
-                |> Helper.remove_tag(fn({tag, _, _}) ->
-                     Enum.member?(["script", "style"], tag)
-                   end)
 
-    html_tree = if opts[:remove_unlikely_candidates], do: Cleaner.remove_unlikely_tree(html_tree), else: html_tree
+    html_tree =
+      html_tree
+      |> Helper.remove_tag(fn {tag, _, _} ->
+        Enum.member?(["script", "style"], tag)
+      end)
+
+    html_tree =
+      if opts[:remove_unlikely_candidates],
+        do: Cleaner.remove_unlikely_tree(html_tree),
+        else: html_tree
+
     html_tree = Cleaner.transform_misused_div_to_p(html_tree)
 
     candidates = CandidateFinder.find(html_tree, opts)
@@ -48,25 +54,34 @@ defmodule Readability.ArticleBuilder do
     cond do
       opts[:remove_unlikely_candidates] ->
         Keyword.put(opts, :remove_unlikely_candidates, false)
+
       opts[:weight_classes] ->
         Keyword.put(opts, :weight_classes, false)
+
       opts[:clean_conditionally] ->
         Keyword.put(opts, :clean_conditionally, false)
-      true -> nil
+
+      true ->
+        nil
     end
   end
 
   defp find_article(candidates, html_tree) do
     best_candidate = CandidateFinder.find_best_candidate(candidates)
-    article_trees = if best_candidate do
-                      find_article_trees(best_candidate, candidates)
-                    else
-                      fallback_candidate = case html_tree |> Floki.find("body") do
-                                             [tree|_] -> %Candidate{html_tree: tree}
-                                             _ -> %Candidate{html_tree: {}}
-                                           end
-                      find_article_trees(fallback_candidate, candidates)
-                    end
+
+    article_trees =
+      if best_candidate do
+        find_article_trees(best_candidate, candidates)
+      else
+        fallback_candidate =
+          case html_tree |> Floki.find("body") do
+            [tree | _] -> %Candidate{html_tree: tree}
+            _ -> %Candidate{html_tree: {}}
+          end
+
+        find_article_trees(fallback_candidate, candidates)
+      end
+
     {"div", [], article_trees}
   end
 
@@ -75,22 +90,21 @@ defmodule Readability.ArticleBuilder do
 
     candidates
     |> Enum.filter(&(&1.tree_depth == best_candidate.tree_depth))
-    |> Enum.filter(fn(candidate) ->
-         candidate == best_candidate
-         || candidate.score >= score_threshold
-         || append?(candidate)
-       end)
-    |> Enum.map(&(to_article_tag(&1.html_tree)))
+    |> Enum.filter(fn candidate ->
+      candidate == best_candidate || candidate.score >= score_threshold || append?(candidate)
+    end)
+    |> Enum.map(&to_article_tag(&1.html_tree))
   end
 
   defp append?(%Candidate{html_tree: html_tree}) when elem(html_tree, 0) == "p" do
     link_density = Scoring.calc_link_density(html_tree)
-    inner_text = html_tree |> Floki.text
-    inner_length = inner_text |> String.length
+    inner_text = html_tree |> Floki.text()
+    inner_length = inner_text |> String.length()
 
-    (inner_length > 80 && link_density < 0.25)
-    || (inner_length < 80 && link_density == 0 && inner_text =~ ~r/\.( |$)/)
+    (inner_length > 80 && link_density < 0.25) ||
+      (inner_length < 80 && link_density == 0 && inner_text =~ ~r/\.( |$)/)
   end
+
   defp append?(_), do: false
 
   defp to_article_tag({tag, attrs, inner_tree} = html_tree) do

--- a/lib/readability/author_finder.ex
+++ b/lib/readability/author_finder.ex
@@ -11,21 +11,24 @@ defmodule Readability.AuthorFinder do
   @spec find(html_tree) :: [binary]
   def find(html_tree) do
     author_names = find_by_meta_tag(html_tree)
+
     if author_names do
       split_author_names(author_names)
     end
   end
 
   def find_by_meta_tag(html_tree) do
-    names = html_tree
-             |> Floki.find("meta[name*=author], meta[property*=author]")
-             |> Enum.map(fn(meta) ->
-                  meta
-                  |> Floki.attribute("content")
-                  |> Enum.join(" ")
-                  |> String.strip
-                end)
-             |> Enum.reject(&(is_nil(&1) || String.length(&1) == 0))
+    names =
+      html_tree
+      |> Floki.find("meta[name*=author], meta[property*=author]")
+      |> Enum.map(fn meta ->
+        meta
+        |> Floki.attribute("content")
+        |> Enum.join(" ")
+        |> String.strip()
+      end)
+      |> Enum.reject(&(is_nil(&1) || String.length(&1) == 0))
+
     if length(names) > 0 do
       hd(names)
     else

--- a/lib/readability/candidate/cleaner.ex
+++ b/lib/readability/candidate/cleaner.ex
@@ -14,9 +14,11 @@ defmodule Readability.Candidate.Cleaner do
   @spec transform_misused_div_to_p(html_tree) :: html_tree
   def transform_misused_div_to_p(content) when is_binary(content), do: content
   def transform_misused_div_to_p([]), do: []
-  def transform_misused_div_to_p([h|t]) do
-    [transform_misused_div_to_p(h)|transform_misused_div_to_p(t)]
+
+  def transform_misused_div_to_p([h | t]) do
+    [transform_misused_div_to_p(h) | transform_misused_div_to_p(t)]
   end
+
   def transform_misused_div_to_p({tag, attrs, inner_tree}) do
     tag = if misused_divs?(tag, inner_tree), do: "p", else: tag
     {tag, attrs, transform_misused_div_to_p(inner_tree)}
@@ -33,16 +35,18 @@ defmodule Readability.Candidate.Cleaner do
   defp misused_divs?("div", inner_tree) do
     !(Floki.raw_html(inner_tree) =~ Readability.regexes(:div_to_p_elements))
   end
+
   defp misused_divs?(_, _), do: false
 
   defp unlikely_tree?({tag, attrs, _}) do
-    idclass_str = attrs
-                  |> Enum.filter_map(&(elem(&1, 0)  =~ ~r/id|class/i), &(elem(&1, 1)))
-                  |> Enum.join("")
+    idclass_str =
+      attrs
+      |> Enum.filter_map(&(elem(&1, 0) =~ ~r/id|class/i), &elem(&1, 1))
+      |> Enum.join("")
+
     str = tag <> idclass_str
 
-    str =~ Readability.regexes(:unlikely_candidate)
-      && !(str =~ Readability.regexes(:ok_maybe_its_a_candidate))
-      && tag != "html"
+    str =~ Readability.regexes(:unlikely_candidate) &&
+      !(str =~ Readability.regexes(:ok_maybe_its_a_candidate)) && tag != "html"
   end
 end

--- a/lib/readability/candidate_finder.ex
+++ b/lib/readability/candidate_finder.ex
@@ -14,20 +14,26 @@ defmodule Readability.CandidateFinder do
   @doc """
   Find candidates that shuld be meaningful article by analysing nodes
   """
-  @spec find(html_tree, options, number) :: [Candidate.t]
+  @spec find(html_tree, options, number) :: [Candidate.t()]
   def find(_, opts \\ [], tree_depth \\ 0)
   def find([], _, _), do: []
-  def find([h|t], opts, tree_depth) do
+
+  def find([h | t], opts, tree_depth) do
     [find(h, opts, tree_depth) | find(t, opts, tree_depth)]
-    |> List.flatten
+    |> List.flatten()
   end
+
   def find(text, _, _) when is_binary(text), do: []
+
   def find({tag, attrs, inner_tree}, opts, tree_depth) do
     html_tree = {tag, attrs, inner_tree}
+
     if candidate?(html_tree) do
-      candidate = %Candidate{html_tree: html_tree,
-                             score: Scoring.calc_score(html_tree, opts),
-                             tree_depth: tree_depth}
+      candidate = %Candidate{
+        html_tree: html_tree,
+        score: Scoring.calc_score(html_tree, opts),
+        tree_depth: tree_depth
+      }
 
       [candidate | find(inner_tree, opts, tree_depth + 1)]
     else
@@ -38,18 +44,20 @@ defmodule Readability.CandidateFinder do
   @doc """
   Find the highest score candidate.
   """
-  @spec find_best_candidate([Candidate.t]) :: Candidate.t
+  @spec find_best_candidate([Candidate.t()]) :: Candidate.t()
   def find_best_candidate([]), do: nil
+
   def find_best_candidate(candidates) do
     candidates
-    |> Enum.max_by(fn(candidate) -> candidate.score end)
+    |> Enum.max_by(fn candidate -> candidate.score end)
   end
 
   defp candidate?(_, depth \\ 0)
   defp candidate?(_, depth) when depth > 2, do: false
-  defp candidate?([h|t], depth), do: candidate?(h, depth) || candidate?(t, depth)
+  defp candidate?([h | t], depth), do: candidate?(h, depth) || candidate?(t, depth)
   defp candidate?([], _), do: false
   defp candidate?(text, _) when is_binary(text), do: false
+
   defp candidate?({_, _, inner_tree} = html_tree, depth) do
     if Helper.candidate_tag?(html_tree) do
       true

--- a/lib/readability/sanitizer.ex
+++ b/lib/readability/sanitizer.ex
@@ -13,12 +13,13 @@ defmodule Readability.Sanitizer do
   @doc """
   Sanitizes article html tree
   """
-  @spec sanitize(html_tree, [Candidate.t], list) :: html_tree
-  def sanitize(html_tree, candidates, opts  \\ []) do
-    html_tree = html_tree
-                |> Helper.remove_tag(&clean_headline_tag?(&1))
-                |> Helper.remove_tag(&clean_unlikely_tag?(&1))
-                |> Helper.remove_tag(&clean_empty_p?(&1))
+  @spec sanitize(html_tree, [Candidate.t()], list) :: html_tree
+  def sanitize(html_tree, candidates, opts \\ []) do
+    html_tree =
+      html_tree
+      |> Helper.remove_tag(&clean_headline_tag?(&1))
+      |> Helper.remove_tag(&clean_unlikely_tag?(&1))
+      |> Helper.remove_tag(&clean_empty_p?(&1))
 
     if opts[:clean_conditionally] do
       html_tree |> Helper.remove_tag(conditionally_cleaing_fn(candidates))
@@ -28,15 +29,19 @@ defmodule Readability.Sanitizer do
   end
 
   defp conditionally_cleaing_fn(candidates) do
-    fn({tag, attrs, _} = tree) ->
+    fn {tag, attrs, _} = tree ->
       if Enum.any?(["table", "ul", "div"], &(&1 == tag)) do
         weight = Scoring.class_weight(attrs)
-        same_tree = candidates
-                    |> Enum.find(%Candidate{}, &(&1.html_tree == tree))
+
+        same_tree =
+          candidates
+          |> Enum.find(%Candidate{}, &(&1.html_tree == tree))
+
         list? = tag == "ul"
+
         cond do
-          weight + same_tree.score < 0
-            -> true
+          weight + same_tree.score < 0 ->
+            true
 
           length(Regex.scan(~r/\,/, Floki.text(tree))) < 10 ->
             # If there are not very many commas, and the number of
@@ -46,35 +51,42 @@ defmodule Readability.Sanitizer do
             img_len = tree |> Floki.find("img") |> length
             li_len = tree |> Floki.find("li") |> length
             input_len = tree |> Floki.find("input") |> length
-            embed_len = tree
-                        |> Floki.find("embed")
-                        |> Enum.reject(&(&1 =~ Readability.regexes(:video)))
-                        |> length
 
-            link_density =  Scoring.calc_link_density(tree)
+            embed_len =
+              tree
+              |> Floki.find("embed")
+              |> Enum.reject(&(&1 =~ Readability.regexes(:video)))
+              |> length
+
+            link_density = Scoring.calc_link_density(tree)
             conent_len = Helper.text_length(tree)
 
-            img_len > p_len                 # too many image
-            || (!list? && li_len > p_len)   # more <li>s than <p>s
-            || input_len > (p_len / 3)      # less than 3x <p>s than <input>s
-            || (!list? && conent_len < Readability.regexes(:min_text_length) && img_len != 1) # too short a content length without a single image
-            || (weight < 25 && link_density > 0.2) # too many links for its weight (#{weight})
-            || (weight >= 25 && link_density > 0.5) # too many links for its weight (#{weight})
-            || ((embed_len == 1 && conent_len < 75) || embed_len > 1) # <embed>s with too short a content length, or too many <embed>s
+            # too many image
+            # more <li>s than <p>s
+            # less than 3x <p>s than <input>s
+            # too short a content length without a single image
+            # too many links for its weight (#{weight})
+            # too many links for its weight (#{weight})
+            # <embed>s with too short a content length, or too many <embed>s
+            img_len > p_len || (!list? && li_len > p_len) || input_len > p_len / 3 ||
+              (!list? && conent_len < Readability.regexes(:min_text_length) && img_len != 1) ||
+              (weight < 25 && link_density > 0.2) || (weight >= 25 && link_density > 0.5) ||
+              ((embed_len == 1 && conent_len < 75) || embed_len > 1)
 
-          true -> false
+          true ->
+            false
         end
       end
     end
   end
 
   defp clean_headline_tag?({tag, attrs, _} = html_tree) do
-    tag =~ ~r/^h\d{1}$/
-    && (Scoring.class_weight(attrs) < 0 || Scoring.calc_link_density(html_tree) > 0.33)
+    tag =~ ~r/^h\d{1}$/ &&
+      (Scoring.class_weight(attrs) < 0 || Scoring.calc_link_density(html_tree) > 0.33)
   end
 
   defp clean_unlikely_tag?({tag, attrs, _}) do
-    attrs_str = attrs |> Enum.map(&(elem(&1, 1))) |> Enum.join("")
+    attrs_str = attrs |> Enum.map(&elem(&1, 1)) |> Enum.join("")
     tag =~ ~r/form|object|iframe|embed/ && !(attrs_str =~ Readability.regexes(:video))
   end
 

--- a/lib/readability/title_finder.ex
+++ b/lib/readability/title_finder.ex
@@ -23,6 +23,7 @@ defmodule Readability.TitleFinder do
         else
           h_title
         end
+
       title when is_binary(title) ->
         title
     end
@@ -54,7 +55,7 @@ defmodule Readability.TitleFinder do
   @doc """
   Find title from h tag
   """
-  @spec h_tag_title(html_tree, String.t) :: binary
+  @spec h_tag_title(html_tree, String.t()) :: binary
   def h_tag_title(html_tree, selector \\ @h_tag_selector) do
     html_tree
     |> find_tag(selector)
@@ -65,6 +66,7 @@ defmodule Readability.TitleFinder do
     case Floki.find(html_tree, selector) do
       [] ->
         []
+
       matches when is_list(matches) ->
         hd(matches)
     end
@@ -73,9 +75,11 @@ defmodule Readability.TitleFinder do
   defp clean_title([]) do
     ""
   end
+
   defp clean_title([title]) when is_binary(title) do
     String.strip(title)
   end
+
   defp clean_title(html_tree) do
     html_tree
     |> Floki.text()

--- a/mix.exs
+++ b/mix.exs
@@ -10,24 +10,23 @@ defmodule Readability.Mixfile do
   use Mix.Project
 
   def project do
-    [app: :readability,
-     version: @version,
-     elixir: "~> 1.3",
-     description: @description,
-     package: package(),
-     build_embedded: Mix.env == :prod,
-     start_permanent: Mix.env == :prod,
-     deps: deps()]
+    [
+      app: :readability,
+      version: @version,
+      elixir: "~> 1.3",
+      description: @description,
+      package: package(),
+      build_embedded: Mix.env() == :prod,
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
   end
 
   # Configuration for the OTP application
   #
   # Type "mix help compile.app" for more information
   def application do
-    [applications: [:logger,
-                    :floki,
-                    :httpoison
-                   ]]
+    [applications: [:logger, :floki, :httpoison]]
   end
 
   # Dependencies can be Hex packages:
@@ -40,20 +39,25 @@ defmodule Readability.Mixfile do
   #
   # Type "mix help deps" for more examples and options
   defp deps do
-    [{:floki, "~> 0.18.0"},
-     {:httpoison, "~> 0.13.0"},
-     {:ex_doc, "~> 0.14", only: :dev},
-     {:credo, "~> 0.6.1", only: [:dev, :test]},
-     {:dialyxir, "~> 0.3", only: [:dev]},
-     {:mock, "~> 0.2.0", only: :test},
+    [
+      {:floki, "~> 0.18.0"},
+      {:httpoison, "~> 0.13.0"},
+      {:ex_doc, "~> 0.14", only: :dev},
+      {:credo, "~> 0.6.1", only: [:dev, :test]},
+      {:dialyxir, "~> 0.3", only: [:dev]},
+      {:mock, "~> 0.2.0", only: :test}
     ]
   end
 
   defp package do
-    [files: ["lib", "mix.exs", "README*", "LICENSE*", "doc"],
-     maintainers: ["Jaehyun Shin"],
-     licenses: ["Apache 2.0"],
-     links: %{"GitHub" => "https://github.com/keepcosmos/readability",
-              "Docs" => "https://hexdocs.pm/readability/Readability.html"}]
+    [
+      files: ["lib", "mix.exs", "README*", "LICENSE*", "doc"],
+      maintainers: ["Jaehyun Shin"],
+      licenses: ["Apache 2.0"],
+      links: %{
+        "GitHub" => "https://github.com/keepcosmos/readability",
+        "Docs" => "https://hexdocs.pm/readability/Readability.html"
+      }
+    ]
   end
 end

--- a/test/readability/candidate/cleaner_test.exs
+++ b/test/readability/candidate/cleaner_test.exs
@@ -29,14 +29,14 @@ defmodule Readability.Candidate.CleanerTest do
 
   test "transform divs containing no block elements", %{html_tree: html_tree} do
     html_tree = Cleaner.transform_misused_div_to_p(html_tree)
-    [{tag, _, _}|_] = html_tree |> Floki.find("#body")
+    [{tag, _, _} | _] = html_tree |> Floki.find("#body")
 
     assert tag == "p"
   end
 
   test "not transform divs that contain block elements", %{html_tree: html_tree} do
     html_tree = Cleaner.transform_misused_div_to_p(html_tree)
-    [{tag, _, _}|_] = html_tree |> Floki.find("#contains_blockquote")
+    [{tag, _, _} | _] = html_tree |> Floki.find("#contains_blockquote")
     assert tag == "div"
   end
 

--- a/test/readability/helper_test.exs
+++ b/test/readability/helper_test.exs
@@ -26,23 +26,25 @@ defmodule Readability.HelperTest do
   end
 
   test "change font tag to span", %{html_tree: html_tree} do
-    expectred = @sample |> String.replace(~r/font/, "span") |> Floki.parse
+    expectred = @sample |> String.replace(~r/font/, "span") |> Floki.parse()
     result = Helper.change_tag(html_tree, "font", "span")
     assert result == expectred
   end
 
   test "remove tag", %{html_tree: html_tree} do
     expected = "<html><body></body></html>" |> parse
-    result = html_tree
-             |> Helper.remove_tag(fn({tag, _, _}) ->
-               tag == "p"
-             end)
+
+    result =
+      html_tree
+      |> Helper.remove_tag(fn {tag, _, _} ->
+        tag == "p"
+      end)
 
     assert result == expected
   end
 
   test "inner text lengt", %{html_tree: html_tree} do
-    result = html_tree |> Helper.text_length
+    result = html_tree |> Helper.text_length()
     assert result == 5
   end
 end

--- a/test/readability/title_finder_test.exs
+++ b/test/readability/title_finder_test.exs
@@ -37,6 +37,7 @@ defmodule Readability.TitleFinderTest do
       </head>
     </html>
     """
+
     title = Readability.TitleFinder.og_title(html)
     assert title == "og title 1"
   end
@@ -52,6 +53,7 @@ defmodule Readability.TitleFinderTest do
       </head>
     </html>
     """
+
     title = Readability.TitleFinder.tag_title(html)
     assert title == "Tag title"
 
@@ -62,6 +64,7 @@ defmodule Readability.TitleFinderTest do
       </head>
     </html>
     """
+
     title = Readability.TitleFinder.tag_title(html)
     assert title == "Tag title"
 
@@ -72,6 +75,7 @@ defmodule Readability.TitleFinderTest do
       </head>
     </html>
     """
+
     title = Readability.TitleFinder.tag_title(html)
     assert title == "Tag title-tag"
 
@@ -82,6 +86,7 @@ defmodule Readability.TitleFinderTest do
       </head>
     </html>
     """
+
     title = Readability.TitleFinder.tag_title(html)
     assert title == "Tag title-tag-title"
 
@@ -95,6 +100,7 @@ defmodule Readability.TitleFinderTest do
       </body>
     </html>
     """
+
     title = Readability.TitleFinder.tag_title(html)
     assert title == "Tag title"
   end
@@ -108,6 +114,7 @@ defmodule Readability.TitleFinderTest do
       </head>
     </html>
     """
+
     title = Readability.TitleFinder.tag_title(html)
     assert title == "tag title 1"
   end
@@ -131,6 +138,7 @@ defmodule Readability.TitleFinderTest do
       </body>
     </html>
     """
+
     title = Readability.TitleFinder.h_tag_title(html)
     assert title == "header 1"
   end

--- a/test/readability_http_test.exs
+++ b/test/readability_http_test.exs
@@ -6,12 +6,9 @@ defmodule ReadabilityHttpTest do
   test "blank response is parsed as plain text" do
     url = "https://tools.ietf.org/rfc/rfc2616.txt"
     content = TestHelper.read_fixture("rfc2616.txt")
-    response = %HTTPoison.Response{
-      status_code: 200,
-      headers: [],
-      body: content}
-    
-    with_mock HTTPoison, [get!: fn(_url, _headers, _opts) -> response end] do
+    response = %HTTPoison.Response{status_code: 200, headers: [], body: content}
+
+    with_mock HTTPoison, get!: fn _url, _headers, _opts -> response end do
       %Readability.Summary{article_text: result_text} = Readability.summarize(url)
 
       assert result_text =~ ~r/3 Protocol Parameters/
@@ -21,12 +18,14 @@ defmodule ReadabilityHttpTest do
   test "text/plain response is parsed as plain text" do
     url = "https://tools.ietf.org/rfc/rfc2616.txt"
     content = TestHelper.read_fixture("rfc2616.txt")
+
     response = %HTTPoison.Response{
       status_code: 200,
       headers: [{"Content-Type", "text/plain"}],
-      body: content}
-    
-    with_mock HTTPoison, [get!: fn(_url, _headers, _opts) -> response end] do
+      body: content
+    }
+
+    with_mock HTTPoison, get!: fn _url, _headers, _opts -> response end do
       %Readability.Summary{article_text: result_text} = Readability.summarize(url)
 
       assert result_text =~ ~r/3 Protocol Parameters/
@@ -38,13 +37,15 @@ defmodule ReadabilityHttpTest do
     content = TestHelper.read_fixture("bbc.html")
     mimes = ["text/html", "application/xml", "application/xhtml+xml"]
 
-    mimes |> Enum.each(fn(mime) ->
+    mimes
+    |> Enum.each(fn mime ->
       response = %HTTPoison.Response{
         status_code: 200,
         headers: [{"Content-Type", mime}],
-        body: content}
-      
-      with_mock HTTPoison, [get!: fn(_url, _headers, _opts) -> response end] do
+        body: content
+      }
+
+      with_mock HTTPoison, get!: fn _url, _headers, _opts -> response end do
         %Readability.Summary{article_html: result_html} = Readability.summarize(url)
 
         assert result_html =~ ~r/connected computing devices\".<\/p><\/div><\/div>$/
@@ -55,12 +56,14 @@ defmodule ReadabilityHttpTest do
   test "response with charset is parsed correctly" do
     url = "https://news.bbc.co.uk/test.html"
     content = TestHelper.read_fixture("bbc.html")
+
     response = %HTTPoison.Response{
       status_code: 200,
       headers: [{"Content-Type", "text/html; charset=UTF-8"}],
-      body: content}
-    
-    with_mock HTTPoison, [get!: fn(_url, _headers, _opts) -> response end] do
+      body: content
+    }
+
+    with_mock HTTPoison, get!: fn _url, _headers, _opts -> response end do
       %Readability.Summary{article_html: result_html} = Readability.summarize(url)
 
       assert result_html =~ ~r/connected computing devices\".<\/p><\/div><\/div>$/
@@ -71,12 +74,14 @@ defmodule ReadabilityHttpTest do
     # HTTP header keys are case insensitive (RFC2616 - Section 4.2)
     url = "https://news.bbc.co.uk/test.html"
     content = TestHelper.read_fixture("bbc.html")
+
     response = %HTTPoison.Response{
       status_code: 200,
       headers: [{"content-Type", "text/html; charset=UTF-8"}],
-      body: content}
-    
-    with_mock HTTPoison, [get!: fn(_url, _headers, _opts) -> response end] do
+      body: content
+    }
+
+    with_mock HTTPoison, get!: fn _url, _headers, _opts -> response end do
       %Readability.Summary{article_html: result_html} = Readability.summarize(url)
 
       assert result_html =~ ~r/connected computing devices\".<\/p><\/div><\/div>$/

--- a/test/readability_test.exs
+++ b/test/readability_test.exs
@@ -7,7 +7,10 @@ defmodule ReadabilityTest do
     nytimes = Readability.article(html, opts)
 
     nytimes_html = Readability.readable_html(nytimes)
-    assert nytimes_html =~ ~r/^<div><div><figure id=\"media-100000004245260\"><div><img src=\"https/
+
+    assert nytimes_html =~
+             ~r/^<div><div><figure id=\"media-100000004245260\"><div><img src=\"https/
+
     assert nytimes_html =~ ~r/major priorities.<\/p><\/div><\/div>$/
 
     nytimes_text = Readability.readable_text(nytimes)
@@ -66,12 +69,17 @@ defmodule ReadabilityTest do
 
     pubmed_html = Readability.readable_html(pubmed)
 
-    assert pubmed_html =~ ~r/^<div><div><h4>BACKGROUND AND OBJECTIVES: <\/h4><p><abstracttext>Although strict blood pressure/
-    assert pubmed_html =~ ~r/different mechanisms yielded potent antihypertensive efficacy with safety and decreased plasma BNP levels.<\/abstracttext><\/p><\/div><\/div>$/
+    assert pubmed_html =~
+             ~r/^<div><div><h4>BACKGROUND AND OBJECTIVES: <\/h4><p><abstracttext>Although strict blood pressure/
+
+    assert pubmed_html =~
+             ~r/different mechanisms yielded potent antihypertensive efficacy with safety and decreased plasma BNP levels.<\/abstracttext><\/p><\/div><\/div>$/
 
     pubmed_text = Readability.readable_text(pubmed)
 
     assert pubmed_text =~ ~r/^BACKGROUND AND OBJECTIVES: \nAlthough strict blood pressure/
-    assert pubmed_text =~ ~r/with different mechanisms yielded potent antihypertensive efficacy with safety and decreased plasma BNP levels.$/
+
+    assert pubmed_text =~
+             ~r/with different mechanisms yielded potent antihypertensive efficacy with safety and decreased plasma BNP levels.$/
   end
 end


### PR DESCRIPTION
Elixir 1.6 released a style guide along with a formatter we can use to format our codebase. Personally I think it makes the codebase more consistent, readable and maintainable. It might be good to have this in this repo, let me know what do you think.