### PR TITLE
Convert relative img paths into absolute

### DIFF
--- a/lib/readability.ex
+++ b/lib/readability.ex
@@ -62,7 +62,8 @@ defmodule Readability do
     replace_xml_version: ~r/<\?xml.*\?>/i,
     normalize: ~r/\s{2,}/,
     video: ~r/\/\/(www\.)?(dailymotion|youtube|youtube-nocookie|player\.vimeo)\.com/i,
-    protect_attrs: ~r/^(?!id|rel|for|summary|title|href|src|alt|srcdoc)/i
+    protect_attrs: ~r/^(?!id|rel|for|summary|title|href|src|alt|srcdoc)/i,
+    img_tag_src: ~r/(<img.*src=['"])([^'"]+)(['"][^>]*>)/Ui
   ]
 
   @markup_mimes ~r/^(application|text)\/[a-z\-_\.\+]+ml(;\s*charset=.*)?$/i
@@ -84,7 +85,9 @@ defmodule Readability do
 
     case is_response_markup(headers) do
       true ->
-        html_tree = Helper.normalize(raw)
+        html_tree =
+          raw
+          |> Helper.normalize(url: url)
 
         article_tree =
           html_tree

--- a/test/readability/helper_test.exs
+++ b/test/readability/helper_test.exs
@@ -11,10 +11,12 @@ defmodule Readability.HelperTest do
           <font>a</fond>
           <p>
             <font>abc</font>
+            <img src="https://example.org/images/foo.png">
           </p>
         </p>
         <p>
           <font>b</font>
+          <img class="img" src="/images/bar.png" alt="alt" />
         </p>
       </body>
     </html>
@@ -43,8 +45,30 @@ defmodule Readability.HelperTest do
     assert result == expected
   end
 
-  test "inner text lengt", %{html_tree: html_tree} do
+  test "inner text length", %{html_tree: html_tree} do
     result = html_tree |> Helper.text_length()
     assert result == 5
+  end
+
+  test "transform img relative paths into absolute" do
+    foo_url = "https://example.org/images/foo.png"
+    bar_url_http = "http://example.org/images/bar.png"
+    bar_url_https = "https://example.org/images/bar.png"
+
+    result_without_scheme =
+      @sample
+      |> Helper.normalize(url: "example.org/blog/a-blog-post")
+      |> Floki.raw_html()
+
+    result_with_scheme =
+      @sample
+      |> Helper.normalize(url: "https://example.org/blog/a-blog-post")
+      |> Floki.raw_html()
+
+    assert result_without_scheme =~ foo_url
+    assert result_without_scheme =~ bar_url_http
+
+    assert result_with_scheme =~ foo_url
+    assert result_with_scheme =~ bar_url_https
   end
 end


### PR DESCRIPTION
Fixes #27 

I wasn't too sure on where to put the conversion. I can change it somewhere, especially since it doesn't feel very right to include the url in the normalization options.