### PR TITLE
Avoid error when html_tree is nil

### DIFF
--- a/lib/readability/helper.ex
+++ b/lib/readability/helper.ex
@@ -83,6 +83,7 @@ defmodule Readability.Helper do
   Count only text length
   """
   @spec text_length(html_tree) :: number
+  def text_length(nil), do: 0
   def text_length(html_tree) do
     html_tree |> Floki.text() |> String.trim() |> String.length()
   end


### PR DESCRIPTION
I think there is a deeper error, but I think we can avoid this error if we just check the html_length before it gets to Floki.