### PR TITLE
Remove deps status badge as HexFaktor discontinued

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Build Status](https://travis-ci.org/keepcosmos/readability.svg?branch=master)](https://travis-ci.org/keepcosmos/readability)
 [![Readability version](https://img.shields.io/hexpm/v/readability.svg)](https://hex.pm/packages/readability)
-[![Deps Status](https://beta.hexfaktor.org/badge/all/github/keepcosmos/readability.svg)](https://beta.hexfaktor.org/github/keepcosmos/readability)
 
 Readability is a tool for extracting and curating the primary readable content of a webpage.  
 Check out The [Documentation](https://hexdocs.pm/readability/Readability.html) for full and detailed guides


### PR DESCRIPTION
HexFaktor is discontinued as of May 2018, as it's not GDPR compliant. An alternative is [Dependabot for Elixir](https://dependabot.com/elixir/). It's free of charge and super easy to setup.